### PR TITLE
[Fix] require hotkey to be pressed once

### DIFF
--- a/.idea/runConfigurations/Run_Standalone.xml
+++ b/.idea/runConfigurations/Run_Standalone.xml
@@ -1,5 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Standalone" type="JetRunConfigurationType">
+    <envs>
+      <env name="env" value="dev" />
+    </envs>
     <option name="MAIN_CLASS_NAME" value="app.cleanmeter.target.desktop.DesktopMainKt" />
     <module name="CleanMeter.target.desktop.main" />
     <shortenClasspath name="NONE" />

--- a/.idea/runConfigurations/Run_Standalone.xml
+++ b/.idea/runConfigurations/Run_Standalone.xml
@@ -1,11 +1,9 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Standalone" type="JetRunConfigurationType">
-    <envs>
-      <env name="env" value="dev" />
-    </envs>
     <option name="MAIN_CLASS_NAME" value="app.cleanmeter.target.desktop.DesktopMainKt" />
     <module name="CleanMeter.target.desktop.main" />
     <shortenClasspath name="NONE" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Run_Standalone.xml
+++ b/.idea/runConfigurations/Run_Standalone.xml
@@ -3,7 +3,6 @@
     <option name="MAIN_CLASS_NAME" value="app.cleanmeter.target.desktop.DesktopMainKt" />
     <module name="CleanMeter.target.desktop.main" />
     <shortenClasspath name="NONE" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/target/desktop/src/main/kotlin/app/cleanmeter/target/desktop/KeyboardHook.kt
+++ b/target/desktop/src/main/kotlin/app/cleanmeter/target/desktop/KeyboardHook.kt
@@ -28,13 +28,14 @@ internal object KeyboardManager {
                     val isCtrl = nativeEvent.modifiers.and(NativeKeyEvent.CTRL_MASK) > 0
                     val isAlt = nativeEvent.modifiers.and(NativeKeyEvent.VC_ALT) > 0
 
-                    if (!isCtrl && !isAlt) return
+                    if (!isCtrl || !isAlt) return
 
                     val event = when (nativeEvent.keyCode) {
                         NativeKeyEvent.VC_F10 -> KeyboardEvent.ToggleOverlay
                         NativeKeyEvent.VC_F11 -> KeyboardEvent.ToggleRecording
                         else -> null
                     }
+                    event?.let { _channel.trySend(it) }
                     event?.let { _channel.trySend(it) }
                 }
             })


### PR DESCRIPTION
- Fixed the issue triggering the overlay and recording shortut only on second press
- The Hotkey now requires **both** ctrl and alt to be pressed. Previously it was possible to open the overlay just by ctrl + f10